### PR TITLE
Begin Y Axis at 0 if not included

### DIFF
--- a/src/jsMain/kotlin/chartjs/Chart_js.kt
+++ b/src/jsMain/kotlin/chartjs/Chart_js.kt
@@ -1264,15 +1264,18 @@ external class Chart {
         var ticks: TickOptions?
             get() = definedExternally
             set(value) = definedExternally
-        var xAxes: Array<ChartXAxe>?
+        var x: ChartXAxe?
             get() = definedExternally
             set(value) = definedExternally
-        var yAxes: Array<ChartYAxe>?
+        var y: ChartYAxe?
             get() = definedExternally
             set(value) = definedExternally
     }
 
     interface CommonAxe {
+        var beginAtZero: Boolean?
+            get() = definedExternally
+            set(value) = definedExternally
         var bounds: String?
             get() = definedExternally
             set(value) = definedExternally

--- a/src/jsMain/kotlin/components/ChartUi.kt
+++ b/src/jsMain/kotlin/components/ChartUi.kt
@@ -67,6 +67,11 @@ fun ChartUi(
                             display = true
                         }
                     }
+                    scales = jso<Chart.ChartScales> {
+                        y = jso { 
+                            beginAtZero = true
+                        }
+                    }
                 }
             })
             onDispose {


### PR DESCRIPTION
Not sure if this is something you'd like to change but since I created the [issue](https://github.com/theapache64/benchart/issues/12), I might as well create a PR.

Please close if this isn't something you want. And it's completely possible something might be wrong in this PR but reading the [ChartJs docs](https://www.chartjs.org/docs/latest/axes/), it didn't look like `xAxes` and `yAxes` arrays were present in the config.